### PR TITLE
Firmware update

### DIFF
--- a/drivers/meross-smart-wifi-garage-door-opener.groovy
+++ b/drivers/meross-smart-wifi-garage-door-opener.groovy
@@ -43,7 +43,6 @@ metadata {
             input('timestamp', 'number', title: 'Timestamp', description: '', required: true, defaultValue: '')
             input('sign', 'text', title: 'Sign', description: '', required: true, defaultValue: '')
             input('uuid', 'text', title: 'UUID', description: '', required: true, defaultValue: '')
-            input('uuid', 'text', title: 'UUID', description: '', required: true, defaultValue: '')
             input('channel', 'number', title: 'Garage Door Port', description: '', required: true, defaultValue: 1)
             input('garageOpenCloseTime','number',title: 'Garage Open/Close time (in seconds)', description:'', required: true, defaultValue: 5)
             input('DebugLogging', 'bool', title: 'Enable debug logging', defaultValue: true)

--- a/drivers/meross-smart-wifi-garage-door-opener.groovy
+++ b/drivers/meross-smart-wifi-garage-door-opener.groovy
@@ -41,7 +41,6 @@ metadata {
             input('timestamp', 'number', title: 'Timestamp', description: '', required: true, defaultValue: '')
             input('sign', 'text', title: 'Sign', description: '', required: true, defaultValue: '')
             input('uuid', 'text', title: 'UUID', description: '', required: true, defaultValue: '')
-            input('uuid', 'text', title: 'UUID', description: '', required: true, defaultValue: '')
             input('channel', 'number', title: 'Garage Door Port', description: '', required: true, defaultValue: 1)
             input('garageOpenCloseTime','number',title: 'Garage Open/Close time (in seconds)', description:'', required: true, defaultValue: 5)
             input('DebugLogging', 'bool', title: 'Enable debug logging', defaultValue: true)


### PR DESCRIPTION
Firmware update patched vulnerabilities and require MessageId, TimeStamp, and Sign values to be different each time.  A unique key is used when creating the values that comes from Meross when logging in.   You can get the key by using this script 
 https://github.com/bapirex/meross-api/blob/master/login.py

I haven't been able to test this on previous firmware versions since I already updated and don't have another device with an older version.